### PR TITLE
 Correctly register argument types with a namespace

### DIFF
--- a/src/main/java/io/github/overlordsiii/villagernames/mixin/ArgumentTypesMixin.java
+++ b/src/main/java/io/github/overlordsiii/villagernames/mixin/ArgumentTypesMixin.java
@@ -22,9 +22,9 @@ public abstract class ArgumentTypesMixin {
 
     @Inject(method = "register()V", at = @At("HEAD"))
     private static void registerOurArgumentTypes(CallbackInfo ci){
-        register("formattingarg", FormattingArgumentType.class, new ConstantArgumentSerializer<>(FormattingArgumentType::format));
-        register("villagername", NameArgumentType.Villager.class, new ConstantArgumentSerializer<>(NameArgumentType::villagerName));
-        register("golemname", NameArgumentType.Golem.class, new ConstantArgumentSerializer<>(NameArgumentType::golemName));
+        register("villagernames:formattingarg", FormattingArgumentType.class, new ConstantArgumentSerializer<>(FormattingArgumentType::format));
+        register("villagernames:villagername", NameArgumentType.Villager.class, new ConstantArgumentSerializer<>(NameArgumentType::villagerName));
+        register("villagernames:golemname", NameArgumentType.Golem.class, new ConstantArgumentSerializer<>(NameArgumentType::golemName));
     }
 
 }


### PR DESCRIPTION
As per [Dinnerbone when namespaces were first introduced](https://www.minecraft.net/en-us/article/minecraft-snapshot-17w43a):

> Please always use your own namespace for anything new that you add, and only use other namespaces if you're explicitly overriding something else. Try not to add new things in `minecraft`, basically.

Violating this practice causes the mod to not work with Minecraft proxies such as [Velocity](https://velocitypowered.com/) which can forward custom argument types from mods with the assistance of [CrossStitch](https://github.com/VelocityPowered/CrossStitch).

(Note this will require the client and server to be updated to work.)