### PR TITLE
Update for Guard Villagers 2.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 
 	modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-level:${project.cca_version}")
 
-	modImplementation 'curse.maven:guardvillagers-571503:4572093'
+	modImplementation 'curse.maven:guardvillagers-571503:4661940'
 
 	modImplementation "maven.modrinth:midnightlib:${project.midnightlib_version}"
 }

--- a/src/main/java/io/github/overlordsiii/villagernames/VillagerNames.java
+++ b/src/main/java/io/github/overlordsiii/villagernames/VillagerNames.java
@@ -10,7 +10,7 @@ import io.github.overlordsiii.villagernames.command.VillagerNameCommand;
 import io.github.overlordsiii.villagernames.config.VillagerConfig;
 import io.github.overlordsiii.villagernames.integration.cca.IntComponent;
 import io.github.overlordsiii.villagernames.integration.cca.RavagerCounterComponent;
-import io.github.overlordsiii.villagernames.integration.villagerguards.VillagerGuardsIntegration;
+import io.github.overlordsiii.villagernames.integration.guardvillagers.GuardVillagersIntegration;
 import io.github.overlordsiii.villagernames.util.NamesLoader;
 import io.github.overlordsiii.villagernames.util.VillagerUtil;
 import io.github.overlordsiii.villagernames.util.dev.NameDebugger;
@@ -92,7 +92,7 @@ public class VillagerNames implements ModInitializer, LevelComponentInitializer 
             } else if (CONFIG.villagerGeneralConfig.illagerEntityNames && entity instanceof RavagerEntity ravagerEntity) {
                 VillagerUtil.createRavagerNames(serverWorld, ravagerEntity);
             } else if (FabricLoader.getInstance().isModLoaded("guardvillagers")) {
-                VillagerGuardsIntegration.createGuardVillagerNames(entity);
+                GuardVillagersIntegration.createGuardVillagerNames(entity);
             } else if (entity instanceof CatEntity catEntity) {
                 VillagerUtil.createCatNames(catEntity);
                 VillagerUtil.updateCatNames(catEntity);

--- a/src/main/java/io/github/overlordsiii/villagernames/integration/guardvillagers/GuardVillagersIntegration.java
+++ b/src/main/java/io/github/overlordsiii/villagernames/integration/guardvillagers/GuardVillagersIntegration.java
@@ -1,8 +1,8 @@
-package io.github.overlordsiii.villagernames.integration.villagerguards;
+package io.github.overlordsiii.villagernames.integration.guardvillagers;
 
 import static io.github.overlordsiii.villagernames.VillagerNames.CONFIG;
 
-import dev.mrsterner.guardvillagers.common.entity.GuardEntity;
+import dev.sterner.common.entity.GuardEntity;
 import io.github.overlordsiii.villagernames.VillagerNames;
 import io.github.overlordsiii.villagernames.api.DefaultNameManager;
 import io.github.overlordsiii.villagernames.util.VillagerUtil;
@@ -11,7 +11,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.VillagerEntity;
 import net.minecraft.text.Text;
 
-public class VillagerGuardsIntegration {
+public class GuardVillagersIntegration {
 
 	public static void createGuardVillagerNames(Entity entity) {
 		if (entity instanceof GuardEntity guardEntity) {

--- a/src/main/java/io/github/overlordsiii/villagernames/mixin/guard/GuardEntityMixin.java
+++ b/src/main/java/io/github/overlordsiii/villagernames/mixin/guard/GuardEntityMixin.java
@@ -4,7 +4,7 @@ import static io.github.overlordsiii.villagernames.VillagerNames.CONFIG;
 
 import java.util.Objects;
 
-import dev.mrsterner.guardvillagers.common.entity.GuardEntity;
+import dev.sterner.common.entity.GuardEntity;
 import io.github.overlordsiii.villagernames.api.DefaultNameManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;


### PR DESCRIPTION
Namespace changed from dev.mrsterner.guardvillagers to dev.sterner.  Updated naming of intergration to be consistent with the modname.